### PR TITLE
UI improvements

### DIFF
--- a/packages/nextjs/components/CategorySelectInputBox.tsx
+++ b/packages/nextjs/components/CategorySelectInputBox.tsx
@@ -60,7 +60,7 @@ const CategorySelectInputBox = ({ className, title, options, selectedOption, onC
     const numberValue = parseFloat(input); // Convert the string to a number
     return numberValue % 1 === 0
       ? numberValue.toString() // Return as an integer if no decimal values
-      : numberValue.toFixed(4).replace(/\.?0+$/, ""); // Format to 4 decimals, remove trailing zeros
+      : numberValue.toFixed(2).replace(/\.?0+$/, ""); // Format to 2 decimals, remove trailing zeros
   }
 
   return (
@@ -78,7 +78,7 @@ const CategorySelectInputBox = ({ className, title, options, selectedOption, onC
       {isOpen && (
         <ul
           tabIndex={0}
-          className="w-full dropdown-content menu rounded-box z-[1] p-2 shadow-inner-xl mt-1 bg-[#3C3731] flex flex-col overflow-y-scroll h-32 flex-nowrap"
+          className="w-full dropdown-content menu rounded-box z-[1] p-2 shadow-inner-xl mt-1 bg-[#3C3731] flex flex-col overflow-y-scroll h-80 flex-nowrap"
         >
           {options?.map(({ section, options }) => {
             return (

--- a/packages/nextjs/components/CategorySelectInputBox.tsx
+++ b/packages/nextjs/components/CategorySelectInputBox.tsx
@@ -36,11 +36,23 @@ const CategorySelectInputBox = ({ className, title, options, selectedOption, onC
     setIsOpen(!isOpen);
   };
 
+  const handleSelectAll = (section: string) => {
+    options?.forEach((network) => {
+      if (network.section === section) {
+        network.options.forEach((option) => {
+          if (!option.selected) {
+            handleClick(section, {
+              ...option,
+              selected: true,
+            });
+          }
+        });
+      }
+    });
+  };
+  
+
   const handleClick = (section: string, option: OptionInfo) => {
-    // const elem = document.activeElement;
-    // if (elem) {
-    //   elem?.blur();
-    // }
     onChange(section, option.value, option.selected, option.amountToDust);
   };
 
@@ -71,7 +83,15 @@ const CategorySelectInputBox = ({ className, title, options, selectedOption, onC
           {options?.map(({ section, options }) => {
             return (
               <div key={section}>
-                <p className="text-sm font-bold my-1 px-2">{section}</p>
+                <div className="flex justify-between items-center">
+                  <p className="text-sm font-bold my-1 px-2">{section}</p>
+                  <button
+                    onClick={() => handleSelectAll(section)}
+                    className="text-xs text-[#f8cd4c] px-2 py-1"
+                  >
+                    Select All
+                  </button>
+                </div>
                 <div>
                   {options.map(({ value, label, disabled, tokenBalance, usdValue, decimals, selected, amountToDust }) => {
                     if (selected) return <div key={value}></div>;

--- a/packages/nextjs/components/InputBox.tsx
+++ b/packages/nextjs/components/InputBox.tsx
@@ -386,7 +386,7 @@ const InputBox = () => {
             </div>
             <p className="font-bold m-0">Input</p>
 
-            <TokenSelector _options={networkOptions2} _updateSpecificOption={updateSpecificOption} _comps={comps} />
+            <TokenSelector _options={updatedOptions2} _updateSpecificOption={updateSpecificOption} _comps={comps} />
 
             <div className="p-[0.4px] bg-[#FFFFFF] rounded my-4"></div>
             <div className="overflow-scroll h-40 mb-4">

--- a/packages/nextjs/components/InputBox.tsx
+++ b/packages/nextjs/components/InputBox.tsx
@@ -74,46 +74,52 @@ const InputBox = () => {
 
   // Update disabled property function
   const updateSpecificOption = (sectionKey: string, optionValue: string, selected: boolean, amountToDust: number) => {
-    const updatedOptions: any[] = networkOptions2.map((section: any) =>
-      section.section === sectionKey
-        ? {
-          ...section,
-          options: section.options.map((option: any) =>
-            option.value === optionValue ? { ...option, selected, amountToDust: Math.min(amountToDust, option.tokenBalance) } : option,
-          ),
-        }
-        : section,
-    );
+    setNetworkOptions2(prevNetworkOptions2 => {
+      const updatedOptions: any[] = prevNetworkOptions2.map((section: any) =>
+        section.section === sectionKey
+          ? {
+            ...section,
+            options: section.options.map((option: any) =>
+              option.value === optionValue
+                ? { ...option, selected, amountToDust: Math.min(amountToDust, option.tokenBalance) }
+                : option,
+            ),
+          }
+          : section
+      );
 
-    const filteredTokens = updatedOptions
-      .flatMap((section: any) => section.options)
-      .filter((option: any) => option.selected);
+      const filteredTokens = updatedOptions
+        .flatMap((section: any) => section.options)
+        .filter((option: any) => option.selected);
 
-    const selectedInputTokens = filteredTokens.map((token: any) => ({
-      name: token.label,
-      decimals: token.decimals,
-      balance: token.tokenBalance,
-      amount: token.amountToDust.toString(),
-      address: token.address,
-      symbol: token.symbol,
-      usdValue: token.usdValue,
-      hasPermit2Allowance: false,
-    }));
+      const selectedInputTokens = filteredTokens.map((token: any) => ({
+        name: token.label,
+        decimals: token.decimals,
+        balance: token.tokenBalance,
+        amount: token.amountToDust.toString(),
+        address: token.address,
+        symbol: token.symbol,
+        usdValue: token.usdValue,
+        hasPermit2Allowance: false,
+      }));
 
-    setInputTokens(selectedInputTokens);
-    setNetworkOptions2(updatedOptions);
+      setInputTokens(selectedInputTokens);
 
-    // Update totalDustInUsd
-    let totalDust = 0;
-    for (let i = 0; i < updatedOptions.length; i++) {
-      for (let j = 0; j < updatedOptions[i].options.length; j++) {
-        if (updatedOptions[i].options[j].selected) {
-          totalDust += updatedOptions[i].options[j].usdValue * updatedOptions[i].options[j].amountToDust / updatedOptions[i].options[j].tokenBalance;
+      // Recalculate totalDustInUsd
+      let totalDust = 0;
+      for (const net of updatedOptions) {
+        for (const opt of net.options) {
+          if (opt.selected) {
+            totalDust += (opt.usdValue * opt.amountToDust) / opt.tokenBalance;
+          }
         }
       }
-    }
-    setTotalDustInUsd(totalDust);
+      setTotalDustInUsd(totalDust);
+
+      return updatedOptions;
+    });
   };
+
 
   const filteredNetworkOptions = networkOptions2
     .map(network => ({
@@ -385,8 +391,8 @@ const InputBox = () => {
             <div className="p-[0.4px] bg-[#FFFFFF] rounded my-4"></div>
             <div className="overflow-scroll h-40 mb-4">
               {compsShort}
-            {/* <AllTokensPrices /> */}
-            {/* <AllTokensBalances address="0xc0f0E1512D6A0A77ff7b9C172405D1B0d73565Bf" /> */}
+              {/* <AllTokensPrices /> */}
+              {/* <AllTokensBalances address="0xc0f0E1512D6A0A77ff7b9C172405D1B0d73565Bf" /> */}
             </div>
             <div className="flex items-center justify-center gap-2">
               <p>Total ≈ </p>

--- a/packages/nextjs/components/InputBox.tsx
+++ b/packages/nextjs/components/InputBox.tsx
@@ -132,7 +132,7 @@ const InputBox = () => {
     const numberValue = parseFloat(input); // Convert the string to a number
     return numberValue % 1 === 0
       ? numberValue.toString() // Return as an integer if no decimal values
-      : numberValue.toFixed(4).replace(/\.?0+$/, ""); // Format to 4 decimals, remove trailing zeros
+      : numberValue.toFixed(2).replace(/\.?0+$/, ""); // Format to 4 decimals, remove trailing zeros
   }
 
   const comps = filteredNetworkOptions.map((e: any, index: number) => {
@@ -168,9 +168,12 @@ const InputBox = () => {
                   type="number"
                   min={0}
                   max={option.tokenBalance}
-                  value={option.amountToDust}
+                  value={Number(option.amountToDust).toFixed(2)} // Format to two decimals
                   onChange={(a: any) => {
-                    const value = Math.min(a.target.value, option.tokenBalance);
+                    // Parse the input value as a float
+                    const enteredValue = parseFloat(a.target.value);
+                    // Ensure it does not exceed tokenBalance
+                    const value = Math.min(isNaN(enteredValue) ? 0 : enteredValue, option.tokenBalance);
                     updateSpecificOption(e.section, option.value, option.selected, value);
                   }}
                   className="w-[70px] text-xs h-full px-1 rounded border bg-[#3C3731] shadow-inner shadow-[inset_0_1px_13px_rgba(0,0,0,0.7)]"

--- a/packages/nextjs/components/InputBox.tsx
+++ b/packages/nextjs/components/InputBox.tsx
@@ -354,7 +354,7 @@ const InputBox = () => {
           <p>{"Loading Tokens..."}</p>
         ) : (
           <>
-            <div className="font-bold m-0 flex items-center">DUST Threshold
+            <div className="font-bold m-0 flex items-center mb-4">DUST Threshold
               <div className="relative group inline-block ml-2">
                 <InformationCircleIcon className="w-5 h-5" />
                 <div className="absolute bottom-full mb-2 hidden group-hover:block w-64 p-2 text-xs text-white bg-black rounded">
@@ -362,7 +362,7 @@ const InputBox = () => {
                 </div>
               </div>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-4 mb-4">
               <div className="relative w-2/3">
                 <input
                   className="input rounded-lg p-1 bg-btn1 shadow-inner-xl p-2 h-8 pr-7 w-full appearance-none
@@ -375,20 +375,20 @@ const InputBox = () => {
                   value={dustThresholdValue}
                   onChange={handleChange}
                 />
-                <span className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500">USD</span>
+                <span className="absolute text-sm inset-y-0 right-0 pr-3 flex items-center text-gray-500">USD</span>
               </div>
             </div>
             <p className="font-bold m-0">Input</p>
 
             <TokenSelector _options={networkOptions2} _updateSpecificOption={updateSpecificOption} _comps={comps} />
 
-            <div className="p-[0.4px] bg-[#FFFFFF] rounded my-3"></div>
-            <div className="overflow-scroll h-40">
+            <div className="p-[0.4px] bg-[#FFFFFF] rounded my-4"></div>
+            <div className="overflow-scroll h-40 mb-4">
               {compsShort}
             {/* <AllTokensPrices /> */}
             {/* <AllTokensBalances address="0xc0f0E1512D6A0A77ff7b9C172405D1B0d73565Bf" /> */}
             </div>
-            <div className="flex items-center justify-center gap-1">
+            <div className="flex items-center justify-center gap-2">
               <p>Total ≈ </p>
               <p>$</p>
               <p>{totalDustInUsd?.toFixed(2)}</p>

--- a/packages/nextjs/components/InputBox.tsx
+++ b/packages/nextjs/components/InputBox.tsx
@@ -17,7 +17,7 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import TokenSelector from "./TokenSelector";
 
 const InputBox = () => {
-  const [dustThresholdValue, setDustThresholdValue] = useState<number>(0);
+  const [dustThresholdValue, setDustThresholdValue] = useState<number>(50);
   const [isSaved, setIsSaved] = useState(false);
   const { inputTokens } = useGlobalState();
 
@@ -364,7 +364,7 @@ const InputBox = () => {
               <div className="relative group inline-block ml-2">
                 <InformationCircleIcon className="w-5 h-5" />
                 <div className="absolute bottom-full mb-2 hidden group-hover:block w-64 p-2 text-xs text-white bg-black rounded">
-                  Dust threshold is the value limit you set to define small token balances (dust). For example, with a $5 threshold, any tokens worth less than $5 are considered dust and can be swapped.
+                  Dust threshold is the value limit you set to define small token balances (dust). For example, with a $50 threshold, any tokens worth less than $50 are considered dust and can be swapped.
                 </div>
               </div>
             </div>
@@ -379,7 +379,7 @@ const InputBox = () => {
                   name="dustThreshold"
                   type="number"
                   value={dustThresholdValue}
-                  onChange={handleChange}
+                  onChange={handleChange}                 
                 />
                 <span className="absolute text-sm inset-y-0 right-0 pr-3 flex items-center text-gray-500">USD</span>
               </div>

--- a/packages/nextjs/components/OutputBox.tsx
+++ b/packages/nextjs/components/OutputBox.tsx
@@ -56,6 +56,8 @@ const OutputBox = () => {
     if (copiedAdd) setReceiverWallet(copiedAdd);
   };
 
+  const isSwapDisabled = receiverWalletMode !== "connected" && (!understoodRisk || !receiverWallet);
+
   return (
     <UserActionBoxContainer>
       {address ? (
@@ -136,7 +138,10 @@ const OutputBox = () => {
                     // style={{ backgroundImage: "url('/assets/confirm_btn.svg')" }}
                     className={`text-[#FFFFFF] p-0 bg-btn1 shadow-inner-xl w-7 min-w-7 h-7 rounded-lg font-normal transition-all duration-700`}
                   >
-                    {understoodRisk && "✔"}
+                    {understoodRisk && (
+                      <span className="text-white">&#10003;</span>
+                    )}
+
                   </button>
                   <span className="text-xs opacity-50">
                     This address is correct and not an exchange wallet. Any tokens sent to the wrong address will be
@@ -146,7 +151,7 @@ const OutputBox = () => {
               </div>
             )}
           </div>
-          <SwapPreview isDisabled={receiverWalletMode !== "connected" && !understoodRisk} />
+          <SwapPreview isDisabled={isSwapDisabled} />
         </>
       ) : (
         <></>

--- a/packages/nextjs/components/SwapPreview/InputToken.tsx
+++ b/packages/nextjs/components/SwapPreview/InputToken.tsx
@@ -72,7 +72,7 @@ const InputToken = ({ _index, _token, _approveIndexState, _tokensEstimatedQuotes
           </div>
         </div>
         <span className="text-[#2DC7FF] flex text-xs">
-          {Number(_token.amount).toFixed(8)} {_token.symbol}
+          {Number(_token.amount).toFixed(2)} {_token.symbol}
           <Image className="ml-1" src="/assets/particles.svg" alt="dust_particles" width={10} height={10} />
         </span>
       </div>

--- a/packages/nextjs/components/SwapResultModal.tsx
+++ b/packages/nextjs/components/SwapResultModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import discordIcon from "~~/public/assets/discord_icon.svg";
@@ -18,6 +18,7 @@ interface Props {
 
 const SwapResultModal = ({ isError, error, open, retryOperation, rebootMachine, amountCurency }: Props) => {
   const ref = useRef<HTMLDialogElement>(null);
+  const [copySuccess, setCopySuccess] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -26,6 +27,25 @@ const SwapResultModal = ({ isError, error, open, retryOperation, rebootMachine, 
       ref.current?.close();
     }
   }, [open]);
+
+  const parseErrorMessage = (error: any) => {
+    if (!error) return "An unexpected error occurred.";
+    return error.message.split(" (")[0]; // Extract the main error message
+  };
+
+  const getErrorDetails = (error: any) => {
+    if (!error) return null;
+    const details = error.message.split(" (")[1]?.split(")")[0];
+    return details; // Replace long bytecode with "0x..."
+  };
+
+  const copyErrorToClipboard = () => {
+    if (error) {
+      navigator.clipboard.writeText(error.message);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000); // Reset the copy success message after 2 seconds
+    }
+  };
 
   return (
     <dialog ref={ref} className="modal">
@@ -52,13 +72,6 @@ const SwapResultModal = ({ isError, error, open, retryOperation, rebootMachine, 
             )}
           </div>
           <form method="dialog" className="w-full flex justify-center mt-6">
-            {/* <button
-              style={{ backgroundImage: "url('/assets/confirm_btn.svg')" }}
-              className="flex-1 text-[#FFFFFF] my-0 text-sm bg-center btn  min-h-0 h-10 rounded-lg"
-              onClick={() => document.getElementById("result_modal").showModal()}
-            >
-              Cancel
-            </button> */}
             <button
               onClick={isError ? retryOperation : rebootMachine}
               className="flex-1 px-6 hover:brightness-50 bg-[url('/button2.png')] bg-no-repeat bg-center bg-cover h-10"
@@ -66,7 +79,41 @@ const SwapResultModal = ({ isError, error, open, retryOperation, rebootMachine, 
               {isError ? "Retry Operation" : "Reboot machine"}
             </button>
           </form>
+          {isError && (
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mt-4 w-3/4 text-center">
+              <strong className="font-bold">Error: </strong>
+              <span className="block sm:inline">{parseErrorMessage(error)}</span>
+              {getErrorDetails(error) && (
+                <div className="text-xs mt-2">
+                  <span>{getErrorDetails(error)}</span>
+                </div>
+              )}
+            </div>
+          )}
+          {isError && (
+            <div className="mt-4 flex flex-col items-center">
+              <div className="relative">
+                <button
+                  onClick={copyErrorToClipboard}
+                  className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded mb-2"
+                >
+                  Copy Error
+                </button>
+                {copySuccess && (
+                  <span className="absolute right-[-20px]  top-[40%] transform -translate-y-1/2 text-success">&#10003;</span>
+                )}
+              </div>
 
+              <div className="flex items-center space-x-4">
+                <span className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                  Contact Support
+                </span>
+                <Link href="https://discord.com/invite/FTSeFc9Yh4" target="_blank" rel="noopener noreferrer">
+                  <Image src={discordIcon} alt="discord" />
+                </Link>
+              </div>
+            </div>
+          )}
           {!isError && (
             <div className="flex justify-center items-center -mt-7 -mb-10">
               <div className="flex gap-3 justify-center">

--- a/packages/nextjs/components/TokenSelector.tsx
+++ b/packages/nextjs/components/TokenSelector.tsx
@@ -60,9 +60,10 @@ const TokenSelector = ({ _options, _updateSpecificOption, _comps }: Props) => {
       >
         {tokensSelected ? (hover ? "Update Selection" : "Tokens Selected") : "Select Tokens"}
       </button>
+      {/*  =============== Token Selection Modal  ==================== */}
       <dialog ref={previewModalRef} className="modal">
         <div className="modal-box bg-[url('/assets/preview_bg.svg')] bg-no-repeat bg-center bg-auto rounded-lg">
-          <div className="w-full h-full h-[450px] flex flex-col justify-between">
+          <div className="w-full h-full h-[530px] flex flex-col justify-between">
             <div className="flex flex-col gap-2">
               <span className="font-bold text-lg">Token Selection</span>
 

--- a/packages/nextjs/components/token-balances/AllTokensBalances.tsx
+++ b/packages/nextjs/components/token-balances/AllTokensBalances.tsx
@@ -4,7 +4,7 @@ import { useTokenBalancesWithMetadataByNetwork } from "~~/hooks/dust/useTokenBal
 
 const networks = [
   { key: "Ethereum", alchemyEnum: Network.ETH_MAINNET },
-  { key: "Matic", alchemyEnum: Network.MATIC_MAINNET },
+  { key: "Polygon", alchemyEnum: Network.MATIC_MAINNET },
   { key: "Binance", alchemyEnum: Network.BNB_MAINNET },
   { key: "Base", alchemyEnum: Network.BASE_MAINNET },
 ];

--- a/packages/nextjs/lib/constants.ts
+++ b/packages/nextjs/lib/constants.ts
@@ -10,7 +10,7 @@ import polSVG from "~~/public/pol.svg";
 
 export const networks = [
   { key: "Ethereum", alchemyEnum: AlchemyNetwork.ETH_MAINNET, chainId: 1 },
-  { key: "Matic", alchemyEnum: AlchemyNetwork.MATIC_MAINNET, chainId: 137 },
+  { key: "Polygon", alchemyEnum: AlchemyNetwork.MATIC_MAINNET, chainId: 137 },
   { key: "Binance", alchemyEnum: AlchemyNetwork.BNB_MAINNET, chainId: 56 },
   { key: "Base", alchemyEnum: AlchemyNetwork.BASE_MAINNET, chainId: 8453 },
   // { key: "Optimism", alchemyEnum: AlchemyNetwork.OPT_MAINNET, chainId: 10 },


### PR DESCRIPTION
- make "Select All" button for choosing all tokens inside one chain
- display errors during swaps, with an option to copy and share details with support
- limit coin input values to 2 decimal places 
- dust threshold with more space in padding/margins
- dust threshold is default at $50  
- ensure the wallet input isn’t empty
- token selection modal made larger
- renamed "Matic" to "Polygon"